### PR TITLE
Removed 'ANZCTR trial registration number' from under the 'Definition…

### DIFF
--- a/docs/source/properties/required/2.1-study-identifier.rst
+++ b/docs/source/properties/required/2.1-study-identifier.rst
@@ -11,8 +11,6 @@ Yes      No
 
 **Definition:** The trial registration number provided by ANZCTR must be in the DataCite record to enable the HeSANDA portal to associate a DataCite metadata record with an ANZCTR metadata record.
 
-ANZCTR trial registration number 
-
 *Metadata fields:*
 
 .. contents:: :local:


### PR DESCRIPTION
…' in 2.1-study-identifier.rst

Remove 'ANZCTR trial registration number' from under the 'Definition' in 2.1 Study identifier

Fixes issue #46